### PR TITLE
x86 benchmarking

### DIFF
--- a/tvm_benchmark/util.py
+++ b/tvm_benchmark/util.py
@@ -71,6 +71,9 @@ def get_network(name, batch_size, dtype='float32'):
         image_shape = (4, 84, 84)
         input_shape = (batch_size,) + image_shape
         net, params = relay.testing.dqn.get_workload(batch_size=batch_size, image_shape=image_shape)
+    elif name == 'dcgan':
+        input_shape = (3, 64, 64)
+        net, params = relay.testing.dcgan.get_workload(batch_size, oshape=input_shape)
     # elif name == 'mxnet':
     #     # an example for mxnet model
     #     from mxnet.gluon.model_zoo.vision import get_model

--- a/tvm_benchmark/x86_cpu_imagenet_bench.py
+++ b/tvm_benchmark/x86_cpu_imagenet_bench.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     parser.add_argument("--network", type=str, choices=
                         ['resnet-18', 'resnet-34', 'resnet-50',
                          'vgg-16', 'vgg-19', 'densenet-121', 'inception_v3',
-                         'mobilenet', 'mobilenet_v2', 'squeezenet_v1.0', 'squeezenet_v1.1', 'mlp', 'custom', 'dqn'],
+                         'mobilenet', 'mobilenet_v2', 'squeezenet_v1.0', 'squeezenet_v1.1', 'mlp', 'custom', 'dqn', 'dcgan'],
                         help='The name of neural network')
     parser.add_argument("--model", type=str, choices=
                         # ['rk3399', 'mate10', 'mate10pro', 'p20', 'p20pro',


### PR DESCRIPTION
From Eddie:

to use a tracker
on either this machine or another machine you can do
`python3 -m tvm.exec.rpc_tracker` which should start a tracker at [addressofmachine:9190]
then on the machine you want to do the computation do
`python3 -m tvm.exec.rpc_server --tracker addressofmachinewithtracker:9190 --key foo`
then when you run this imagenet bench script using the `foo` key should line up
you can check if the rpc server is successfully registered with
`python3 -m tvm.exec.query_rpc_tracker --host addressofmachine --port 9190`

To run the benchmark, run `python3 tvm_benchmark/x86_cpu_imagenet_bench.py --network resnet-18 --rpc-key foo`