### PR TITLE
Correct Relay->VTA data parsing, simplify time reporting

### DIFF
--- a/experiments/relay_to_vta/summarize.py
+++ b/experiments/relay_to_vta/summarize.py
@@ -5,7 +5,8 @@ from common import invoke_main, write_status, write_summary, sort_data
 
 SIM_TARGETS = {'sim', 'tsim'}
 PHYS_TARGETS = {'pynq'}
-METADATA_KEYS = {'timestamp', 'tvm_hash'}
+METADATA_KEYS = {'timestamp', 'tvm_hash',
+                 'start_time', 'end_time', 'time_delta'}
 
 def main(data_dir, config_dir, output_dir):
     config, msg = validate(config_dir)

--- a/experiments/relay_to_vta/visualize.py
+++ b/experiments/relay_to_vta/visualize.py
@@ -14,7 +14,8 @@ DEVICE_TO_TEXT = {
     'arm_cpu': 'Mobile CPU',
     'vta': 'Mobile CPU w/ FPGA'
 }
-METADATA_KEYS = {'timestamp', 'tvm_hash'}
+METADATA_KEYS = {'timestamp', 'tvm_hash',
+                 'start_time', 'end_time', 'time_delta'}
 
 def generate_arm_vta_comparisons(data, output_prefix):
     comparison_dir = os.path.join(output_prefix, 'comparison')

--- a/shared/python/slack_util.py
+++ b/shared/python/slack_util.py
@@ -14,14 +14,10 @@ def generate_ping_list(user_ids):
     return ', '.join(['<@{}>'.format(user_id) for user_id in user_ids])
 
 
-def build_field(title='', value='', tm_start=None, tm_end=None, duration=None, short=False):
+def build_field(title='', value='', short=False):
     ret = {'value': value, 'short': short}
     if title != '':
         ret['title'] = title
-    if tm_start and tm_end and duration:
-        ret['value'] = f'_Starts at: {tm_start}_ \n _Ends at: {tm_end}_ \n _Duration: {duration}_\n\n' + ret['value']
-    else:
-        ret['value'] = f'*No Timing Info Recorded*\n' + ret['value']
     return ret
 
 

--- a/subsystem/exp_results/run.py
+++ b/subsystem/exp_results/run.py
@@ -12,15 +12,24 @@ from slack_util import (generate_ping_list,
                         build_field, build_attachment, build_message,
                         post_message)
 
-def failed_experiment_field(exp, stage_statuses, stage, start_time=None, end_time=None, duration=None, notify=None):
+def attach_duration(message, duration=None):
+    if duration is None:
+        return message
+    return '_Duration: {}_\n\n{}'.format(duration, message)
+
+
+def failed_experiment_field(exp, stage_statuses, stage, duration=None, notify=None):
     message = 'Failed at stage {}:\n{}'.format(
         stage,
         textwrap.shorten(stage_statuses[stage]['message'], width=280))
 
+    if duration is not None:
+        message += '\nTime to failure: {}'.format(duration)
+
     if notify is not None:
         message += '\nATTN: {}'.format(generate_ping_list(notify))
 
-    return build_field(title=exp, value=message, tm_start=start_time, tm_end=end_time, duration=duration)
+    return build_field(title=exp, value=message)
 
 
 def main(config_dir, home_dir, output_dir):
@@ -50,7 +59,7 @@ def main(config_dir, home_dir, output_dir):
 
         exp_conf = info.read_exp_config(exp_name)
         exp_status = info.exp_status_dir(exp_name)
-        run_status = validate_json(exp_status, 'start_time', 'end_time', 'time_delta', filename='run.json')
+        run_status = validate_json(exp_status, 'time_delta', filename='run.json')
 
         exp_title = exp_name if 'title' not in exp_conf else exp_conf['title']
         notify = exp_conf['notify']
@@ -67,10 +76,9 @@ def main(config_dir, home_dir, output_dir):
             if not stage_statuses[stage]['success']:
                 failed_experiments.append(
                     failed_experiment_field(exp_title, stage_statuses,
-                                            stage, start_time=run_status.get('start_time'),
-                                                     end_time=run_status.get('end_time'),
-                                                     duration=run_status.get('time_delta'),
-                                                     notify=notify))
+                                            stage,
+                                            duration=run_status.get('time_delta'),
+                                            notify=notify))
                 failure = True
                 break
 
@@ -85,8 +93,9 @@ def main(config_dir, home_dir, output_dir):
 
         summary = info.read_exp_summary(exp_name)
         successful_experiments.append(
-            build_field(summary['title'], summary['value'], run_status.get('start_time'),\
-                                    run_status.get('end_time'), run_status.get('time_delta')))
+            build_field(summary['title'],
+                        attach_duration(summary['value'],
+                                        run_status.get('time_delta'))))
 
     # produce messages
     attachments = []


### PR DESCRIPTION
The Relay->VTA experiment made assumptions about the number of metadata fields that would be present in `data.json`, which I missed when reviewing #45 

I also decided to only include the experiment duration in the Slack message to slim down the presentation.