### PR TITLE
Add timeout to Relay->VTA RPC session

### DIFF
--- a/experiments/relay_to_vta/run.py
+++ b/experiments/relay_to_vta/run.py
@@ -75,7 +75,8 @@ def init_remote(vta_env, config):
         device_host = config.get('pynq_rpc_host', '192.168.2.99')
         device_port = config.get('pynq_rpc_port', 9091)
         if not tracker_host or not tracker_port:
-            remote = rpc.connect(device_host, device_port)
+            remote = rpc.connect(device_host, device_port,
+                                 session_timeout=config.get('timeout', 300))
         else:
             remote = autotvm.measure.request_remote(vta_env.TARGET, tracker_host, tracker_port, timeout=10000)
 

--- a/experiments/relay_to_vta/validate_config.py
+++ b/experiments/relay_to_vta/validate_config.py
@@ -16,7 +16,8 @@ def validate(config_dir):
         config,
         {
             'n_times_per_input': 4,
-            'num_reps': 3
+            'num_reps': 3,
+            'timeout': 300
         },
         {
             'models': {'resnet18_v1'},
@@ -27,7 +28,8 @@ def validate(config_dir):
             'tracker_host': string_cond(),
             'tracker_port': non_negative_cond(),
             'n_times_per_input': non_negative_cond(),
-            'num_reps': non_negative_cond()
+            'num_reps': non_negative_cond(),
+            'timeout': non_negative_cond()
         }
     )
 


### PR DESCRIPTION
The Relay->VTA benchmark presently does not specify a timeout for the TVM RPC session. This can lead to an interminable wait if the device does not respond, which halts the dashboard in its tracks. This PR adds a timeout to ensure a clean failure in such cases.