### PR TITLE
[bugfix] Ensure illegal characters cannot be quoted in status.json

### DIFF
--- a/shared/bash/common.sh
+++ b/shared/bash/common.sh
@@ -38,9 +38,10 @@ function emit_status_file {
         flag_str="false"
     fi
 
-    # have to filter out newlines from the message and escape quotes
-    # or it won't be valid JSON
-    altered_msg=$(echo "$msg" | sed 's/$/\\n/' | tr -d '\n' | sed 's/"/\\"/g')
+    # Have to filter out newlines from the message and escape quotes
+    # or it won't be valid JSON.
+    # Also uses iconv to trim non-ASCII characters to prevent JSON parsing errors later.
+    altered_msg=$(echo "$msg" | sed 's/$/\\n/' | tr -d '\n' | sed 's/"/\\"/g' | iconv -c -t ascii)
     content="{\"success\": $flag_str, \"message\": \"$altered_msg\"}"
     echo "$content" > "$dest/status.json"
 }


### PR DESCRIPTION
Encountered a bug where the "safety net" that logs a task's output and records a failing status if it exists with an error actually triggered a JSON parsing bug due to console control characters being left in the logged output. This change should sanitize those away.