### PR TITLE
[api update] Remove outdated references to relay.backend.interpreter.TensorValue

### DIFF
--- a/experiments/char_rnn/relay_rnn/network.py
+++ b/experiments/char_rnn/relay_rnn/network.py
@@ -3,7 +3,6 @@ import tvm
 from tvm import relay
 from tvm.relay import op
 from tvm.relay import create_executor, Module
-from tvm.relay.backend.interpreter import TensorValue
 from tvm.relay.prelude import Prelude
 import aot
 

--- a/experiments/char_rnn/relay_rnn/util.py
+++ b/experiments/char_rnn/relay_rnn/util.py
@@ -42,8 +42,6 @@ def random_training_example():
     target_line_tensor = targetTensor(line)
     return category_tensor, input_line_tensor, target_line_tensor
 
-from tvm.relay.backend.interpreter import TensorValue
-
 def sample(rnn, category, start_letter='A'):
     category_tensor = categoryTensor(category)
     input = inputTensor(start_letter)

--- a/experiments/treelstm/relay_tlstm/converter.py
+++ b/experiments/treelstm/relay_tlstm/converter.py
@@ -1,7 +1,7 @@
 import torch
 import tvm
 from tvm import relay
-from tvm.relay.backend.interpreter import Value, TupleValue, ConstructorValue, TensorValue
+from tvm.relay.backend.interpreter import TupleValue, ConstructorValue
 from tvm.relay import testing, create_executor
 from tvm.relay.prelude import Prelude
 
@@ -43,7 +43,7 @@ def from_list(p, l, t):
 # convert tensors
 def pytorch_to_relay(tensor):
     #print(tensor.shape)
-    return TensorValue(relay.const(tensor.detach().cpu().numpy().reshape((1, 300)), dtype='float32').data)
+    return relay.const(tensor.detach().cpu().numpy().reshape((1, 300)), dtype='float32').data
 
 
 def from_tree(p, rt, t):

--- a/experiments/treelstm/relay_tlstm/network.py
+++ b/experiments/treelstm/relay_tlstm/network.py
@@ -3,7 +3,6 @@ import tvm
 from tvm import relay
 from tvm.relay import op
 from tvm.relay import create_executor, Module
-from tvm.relay.backend.interpreter import TensorValue
 from tvm.relay.prelude import Prelude
 from tvm.relay.testing import add_nat_definitions
 import aot


### PR DESCRIPTION
TVM PR [4643](https://github.com/apache/incubator-tvm/pull/4643) unified the tensor representation in TVM by removing `tvm.relay.interpreter.TensorValue` and replacing its use uniformly with TVM's NDArrays. This PR updates the TVM experiments by removing all remaining references to this outdated API.