### PR TITLE
[API update] Remove outdated reference to tvm.backend.interpreter.TupleValue

### DIFF
--- a/experiments/treelstm/relay_tlstm/converter.py
+++ b/experiments/treelstm/relay_tlstm/converter.py
@@ -1,7 +1,7 @@
 import torch
 import tvm
 from tvm import relay
-from tvm.relay.backend.interpreter import TupleValue, ConstructorValue
+from tvm.relay.backend.interpreter import ConstructorValue
 from tvm.relay import testing, create_executor
 from tvm.relay.prelude import Prelude
 


### PR DESCRIPTION
There was an unused import of `tvm.backend.interpreter.TupleValue` in the TreeLSTM experiment, which is removed in this PR. This is no longer a valid import since TVM PR [4693](https://github.com/apache/incubator-tvm/pull/4693) unified the runtime's ADT and tuple representations.