### PR TITLE
[API update] Rename tvm.relay.Module to tvm.IRModule

### DIFF
--- a/experiments/char_rnn/relay_rnn/char_rnn_generator.py
+++ b/experiments/char_rnn/relay_rnn/char_rnn_generator.py
@@ -9,8 +9,9 @@ import math
 import numpy as np
 import tvm
 from tvm import relay
+from tvm import IRModule as Module
 from tvm.relay import op
-from tvm.relay import create_executor, Module
+from tvm.relay import create_executor
 from tvm.relay.prelude import Prelude
 
 import language_data as data

--- a/experiments/char_rnn/relay_rnn/network.py
+++ b/experiments/char_rnn/relay_rnn/network.py
@@ -1,8 +1,9 @@
 import numpy as np
 import tvm
 from tvm import relay
+from tvm import IRModule as Module
 from tvm.relay import op
-from tvm.relay import create_executor, Module
+from tvm.relay import create_executor
 from tvm.relay.prelude import Prelude
 import aot
 

--- a/experiments/treelstm/relay_tlstm/network.py
+++ b/experiments/treelstm/relay_tlstm/network.py
@@ -1,8 +1,9 @@
 import numpy as np
 import tvm
 from tvm import relay
+from tvm import IRModule as Module
 from tvm.relay import op
-from tvm.relay import create_executor, Module
+from tvm.relay import create_executor
 from tvm.relay.prelude import Prelude
 from tvm.relay.testing import add_nat_definitions
 import aot


### PR DESCRIPTION
TVM PR [4877](https://github.com/apache/incubator-tvm/pull/4877) made a number of API changes, including changing the Relay module to `tvm.IRModule`. This PR updates references to the Module in experiments