### PR TITLE
[bugfix] Always include description at the top of the Slack summary

### DIFF
--- a/subsystem/exp_results/run.py
+++ b/subsystem/exp_results/run.py
@@ -103,7 +103,6 @@ def main(config_dir, home_dir, output_dir):
         attachments.append(
             build_attachment(
                 title='Successful benchmarks',
-                pretext=description,
                 fields=successful_experiments))
     if failed_experiments:
         attachments.append(
@@ -127,7 +126,8 @@ def main(config_dir, home_dir, output_dir):
     success, report = post_message(
         webhook,
         build_message(
-            text='Dashboard Results',
+            text='*Dashboard Results*{}'.format(
+                '\n' + description if description != '' else ''),
             attachments=attachments))
     write_status(output_dir, success, report)
 


### PR DESCRIPTION
Previously, the Slack description for the experiment summary subsystem would only show up as the "pretext" to the successful experiments message, meaning it would show up above that message. However, if no experiment succeeded, that message is skipped, meaning that the description will also be skipped. This PR corrects this unintended behavior by appending the description to the top-level message text instead.