### PR TITLE
[hotfix] Update MKL config to fix TVM build

### DIFF
--- a/dashboard/config.cmake
+++ b/dashboard/config.cmake
@@ -102,10 +102,22 @@ set(USE_LLVM ON)
 # Whether use BLAS, choices: openblas, mkl, atlas, apple
 set(USE_BLAS none)
 
-# /path/to/mkl: mkl root path when use mkl blas library
-# set(USE_MKL_PATH /opt/intel/mkl) for UNIX
-# set(USE_MKL_PATH ../IntelSWTools/compilers_and_libraries_2018/windows/mkl) for WIN32
-set(USE_MKL_PATH none)
+# Whether to use MKL
+# Possible values:
+# - ON: Enable MKL
+# - /path/to/mkl: mkl root path
+# - OFF: Disable MKL
+# set(USE_MKL /opt/intel/mkl) for UNIX
+# set(USE_MKL ../IntelSWTools/compilers_and_libraries_2018/windows/mkl) for WIN32
+# set(USE_MKL <path to venv or site-packages directory>) if using `pip install mkl`
+set(USE_MKL OFF)
+
+# Whether use MKLDNN library
+set(USE_MKLDNN OFF)
+
+# Whether use OpenMP thread pool, choices: gnu, intel
+# Note: "gnu" uses gomp library, "intel" uses iomp5 library
+set(USE_OPENMP none)
 
 # Whether use contrib.random in runtime
 set(USE_RANDOM OFF)


### PR DESCRIPTION
TVM PR [#6182](https://github.com/apache/incubator-tvm/pull/6182/files) changed how MKL is configured in TVM, which made the `config.cmake` in this repo invalid and caused TVM to fail to build. This update corrects the configuration to match the newest requirements.