### PR TITLE
[hotfix] Update to new graph executor API

### DIFF
--- a/shared/python/relay_util.py
+++ b/shared/python/relay_util.py
@@ -144,7 +144,7 @@ def setup_relay_mod(net, image_shape, input_name, params, dev, opt,
                             disabled_pass=disabled_pass):
         graph, lib, params = relay.build(net, 'llvm' if dev == 'cpu' else 'cuda', params=params)
 
-    mod = tvm.contrib.graph_runtime.create(graph, lib, ctx=device)
+    mod = tvm.contrib.graph_executor.create(graph, lib, device)
     mod.set_input(**params)
     mod.set_input(input_name,
                   tvm.nd.array((np.random.uniform(size=image_shape)).astype('float32')))


### PR DESCRIPTION
The old [graph runtime](https://github.com/apache/tvm/blob/ad775b89780a1fc04969faf2f7eebfeca37a1aa0/python/tvm/contrib/graph_runtime.py) in TVM has been changed to the [graph executor](https://github.com/apache/tvm/blob/ad775b89780a1fc04969faf2f7eebfeca37a1aa0/python/tvm/contrib/graph_executor.py), with a slight change in API. This PR switches to the new API.