### PR TITLE
[Hotfix] Do not use TSim or Verilator

### DIFF
--- a/dashboard/config.cmake
+++ b/dashboard/config.cmake
@@ -150,7 +150,9 @@ set(USE_ANTLR OFF)
 set(USE_VTA_FSIM ON)
 
 # Whether to build cycle-accurate VTA simulator driver
-set(USE_VTA_TSIM ON)
+set(USE_VTA_TSIM OFF)
+
+set(USE_VERILATOR OFF)
 
 # Whether to build VTA FPGA driver (device side only)
 set(USE_VTA_FPGA OFF)


### PR DESCRIPTION
The recent use of Verilator in TVM's VTA libraries was causing builds to break (don't know the exact commit with which this started). We don't need it for our experiments, so this update turns off Verilator and the VTA cycle-accurate simulator to fix the build.